### PR TITLE
[Audio] Update Lavalink.jar build

### DIFF
--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -235,7 +235,7 @@ class LavalinkVersion:
 
 
 class ServerManager:
-    JAR_VERSION: Final[str] = LavalinkOldVersion("3.4.0", build_number=1350)
+    JAR_VERSION: Final[str] = LavalinkVersion(3, 7, 5):
     LAVALINK_DOWNLOAD_URL: Final[str] = (
         "https://github.com/Cog-Creators/Lavalink-Jars/releases/download/"
         f"{JAR_VERSION}/"


### PR DESCRIPTION
### Description of the changes

This changes audio's manager to download and use version 3.7.5 of our Lavalink.jar.

### Have the changes in this PR been tested?

No


Lavalink changelog for us:
```
Fixed Twitch playback.
Plain word search queries should work again.
```