### PR TITLE
Bump YT plugin to 1.13.1

### DIFF
--- a/redbot/cogs/audio/managed_node/version_pins.py
+++ b/redbot/cogs/audio/managed_node/version_pins.py
@@ -12,7 +12,7 @@ __all__ = (
 
 
 JAR_VERSION: Final[LavalinkVersion] = LavalinkVersion(3, 7, 12, red=1)
-YT_PLUGIN_VERSION: Final[str] = "1.13.0"
+YT_PLUGIN_VERSION: Final[str] = "1.13.1"
 # keep this sorted from oldest to latest
 SUPPORTED_JAVA_VERSIONS: Final[Tuple[int, ...]] = (11, 17)
 LATEST_SUPPORTED_JAVA_VERSION: Final = SUPPORTED_JAVA_VERSIONS[-1]


### PR DESCRIPTION
### Description of the changes

Bump the yt source plugin to 1.13.1.

### Have the changes in this PR been tested?

No. Do not release without a merged PR to rearrange source order and add client options to the application.yml.